### PR TITLE
Add a basic gitignore file (based on other tree-sitter-* projects)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+*.log


### PR DESCRIPTION
Hello, I'm Martin from r2c, working on [semgrep](https://semgrep.dev). 

This PR adds a `.gitignore` file, keeping the git status clean after a build. We rely on this to check that we don't have uncommitted changes when releasing generated code from [ocaml-tree-sitter](https://github.com/returntocorp/ocaml-tree-sitter).

~~I also removed the `package-lock.json` file to align with the other tree-sitter-* projects such as https://github.com/tree-sitter/tree-sitter-javascript/blob/master/.gitignore.~~

/cc @zythosec who started the R integration into semgrep.
