### PR TITLE
Add new highlight groups

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,10 +1,16 @@
 ; highlights.scm
 
-(call (identifier) @function.method)
+(call function: (identifier) @function)
+(namespace_get function: (identifier) @function.method)
+(namespace_get_internal function: (identifier) @function.method)
 
 ; Literals
 
 (integer) @number
+
+(float) @number
+
+(complex) @number
 
 (string) @string
 
@@ -21,6 +27,35 @@
  "<<-"
  "->"
 ] @operator
+
+(unary operator: [
+  "-"
+  "+"
+  "!"
+  "~"
+] @operator)
+
+(binary operator: [
+  "-"
+  "+"
+  "*"
+  "/"
+  "^"
+  "<"
+  ">"
+  "<="
+  ">="
+  "=="
+  "!="
+  "||"
+  "|"
+  "&&"
+  "&"
+  ":"
+  "~"
+] @operator)
+
+(special) @operator
 
 [
  "("


### PR DESCRIPTION
This PR adds new highlight groups. I tried following existing practice in other languages. In particular, group `@function` seems to be used for both function calls and function definition. I also decided to use `@function.method` for namespace calls, which might be questionable as it can have not only functions, but seems to be appropriate.

I added those groups which I could think of. If there are some highlighting groups which you wanted to created but never got time, please let me know.