### PR TITLE
add new highlights

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -5,8 +5,10 @@
  (arguments
   name: (identifier) @parameter ))
 
-(namespace_get function: (identifier) @function.method)
-(namespace_get_internal function: (identifier) @function.method)
+(lambda_function "\\" @operator)
+
+(namespace_get function: (identifier) @method)
+(namespace_get_internal function: (identifier) @method)
 
 (namespace_get namespace: (identifier) @namespace
  "::" @operator)
@@ -17,7 +19,7 @@
 
 (integer) @number
 
-(float) @number
+(float) @float
 
 (complex) @number
 
@@ -83,20 +85,33 @@
   "]]" @punctuation.bracket)
 
 [
- "while"
- "if"
- "else"
- "function"
- "repeat"
- "for"
  "in"
  (dots)
- (true)
- (false)
  (break)
  (next)
  (inf)
- (nan)
- (na)
- (null)
 ] @keyword
+
+[
+  (nan)
+  (na)
+  (null)
+] @type.builtin
+
+[
+  "if"
+  "else"
+] @conditional
+
+[
+  "while"
+  "repeat"
+  "for"
+] @repeat
+
+[
+  (true)
+  (false)
+] @boolean
+
+"function" @keyword.function

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -115,3 +115,6 @@
 ] @boolean
 
 "function" @keyword.function
+
+; Error
+(ERROR) @error

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -27,7 +27,7 @@
 
 (comment) @comment
 
-(formal_parameters (identifier) @variable.parameter)
+(formal_parameters (identifier) @parameter)
 
 (identifier) @variable
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,8 +1,17 @@
 ; highlights.scm
 
 (call function: (identifier) @function)
+(call arguments:
+ (arguments
+  name: (identifier) @parameter ))
+
 (namespace_get function: (identifier) @function.method)
 (namespace_get_internal function: (identifier) @function.method)
+
+(namespace_get namespace: (identifier) @namespace
+ "::" @operator)
+(namespace_get_internal namespace: (identifier) @namespace
+ ":::" @operator)
 
 ; Literals
 
@@ -66,6 +75,12 @@
  "{"
  "}"
 ] @punctuation.bracket
+
+(dollar "$" @operator)
+
+(subset2
+  "[[" @punctuation.bracket
+  "]]" @punctuation.bracket)
 
 [
  "while"


### PR DESCRIPTION
This PR add new hightlights.

1. named arguments in call functions as `@parameter`
2. library name in `namespace_get_internal` and `namespace_get` as `@namespace`
3. `::` and `:::` as `@operator`
4. dollar `$` as `@operator`
5. subset2 `[[...]]` as `@punctuation.bracket`
6. lambda_function prefix `\` as `@operator`
7. function as `@keyword.function`
8. `TRUE` and `FALSE` as `@boolean`
9. `nan`, `na` and `null` as `@type.builtin`
10. `if` and `else` as `@conditional`
11. `while`, `repeat` and `for` as `@repeat`
12. `float` as `@float`

### Before:

Using `highlight` from [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/5706b1346b3b79cf2d61006c1a2b77775506ccf3/queries/r/highlights.scm)

![image](https://user-images.githubusercontent.com/16160544/141602374-58ea276e-9f59-4ddc-b55a-b525f329d32d.png)


Using `highlight` from this repo:
![image](https://user-images.githubusercontent.com/16160544/141602432-fda23b82-0180-47a6-a8f3-aa07c8c1c573.png)


### After:
![image](https://user-images.githubusercontent.com/16160544/141601889-aa1c4b97-43e1-4efc-8af4-83eca338c261.png)

Note: `@boolean` and `@keyword.function` has same color because my neovim config use same color

