### PR TITLE
Use version range for `tree-sitter` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Using this range avoids the Rust compiler error,

```
expected struct `tree_sitter::Language`, found a different struct `tree_sitter::Language`
perhaps two different versions of crate `tree_sitter` are being used?
```

which is encountered when using this crate along side `tree-sitter-python`, `tree-sitter-javascript` and `tree-sitter-typescript`. The range is consistent with the range used in those crates e.g. https://github.com/tree-sitter/tree-sitter-python/blob/master/Cargo.toml).