### PR TITLE
Update version and fix repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "tree-sitter-r"
 description = "R grammar for the tree-sitter parsing library"
-version = "0.19.3"
+version = "0.19.4"
 authors = [
     "Jim Hester <jim.hester@rstudio.com>"
 ]
 license = "MIT"
 keywords = ["incremental", "parsing", "R"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-r"
+repository = "https://github.com/r-lib/tree-sitter-r"
 edition = "2018"
 
 build = "bindings/rust/build.rs"


### PR DESCRIPTION
Sorry, I didn't notice this in my previous PR, but the repo URL was wrong (and therefore so was the link on crates.io). I also updated the version number.