### PR TITLE
Ensure newlines are only consumed if the following `optional()` bit actually occurs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -201,8 +201,7 @@ module.exports = grammar({
     function: $ => prec.right(seq(
       choice("\\", "function"),
       field("parameters", $.parameters),
-      repeat($._newline),
-      optional(field("body", $._expression))
+      optional(seq(repeat($._newline), field("body", $._expression)))
     )),
 
     // NOTE: We include "(" and ")" as part of the rule here to allow
@@ -228,8 +227,7 @@ module.exports = grammar({
       ")",
       repeat($._newline),
       field("consequence", $._expression),
-      repeat($._newline),
-      optional(seq("else", field("alternative", $._expression)))
+      optional(seq(repeat($._newline), "else", field("alternative", $._expression)))
     )),
 
     for: $ => prec.right(seq(
@@ -240,8 +238,7 @@ module.exports = grammar({
       "in",
       field("sequence", $._expression),
       ")",
-      repeat($._newline),
-      optional(field("body", $._expression))
+      optional(seq(repeat($._newline), field("body", $._expression)))
     )),
 
     while: $ => prec.right(seq(
@@ -250,14 +247,12 @@ module.exports = grammar({
       "(",
       field("condition", $._expression),
       ")",
-      repeat($._newline),
-      optional(field("body", $._expression))
+      optional(seq(repeat($._newline), field("body", $._expression)))
     )),
 
     repeat: $ => prec.right(seq(
       "repeat",
-      repeat($._newline),
-      optional(field("body", $._expression))
+      optional(seq(repeat($._newline), field("body", $._expression)))
     )),
 
     // Blocks.

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -50,22 +50,27 @@
             }
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "body",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -233,18 +238,18 @@
             }
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
                 "type": "SEQ",
                 "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
                   {
                     "type": "STRING",
                     "value": "else"
@@ -313,22 +318,27 @@
             "value": ")"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "body",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -372,22 +382,27 @@
             "value": ")"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "body",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -408,22 +423,27 @@
             "value": "repeat"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_newline"
-            }
-          },
-          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "body",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_newline"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"


### PR DESCRIPTION
I thought this would be easy but something still isn't quite right