### PR TITLE
Remove unused UNIX specific header

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,8 +1,6 @@
 
 #include <tree_sitter/parser.h>
 
-#include <unistd.h>
-
 #include <cwctype>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
It came in here, but I don't see any reason for it? 
https://github.com/r-lib/tree-sitter-r/commit/ade0cc6856dfb1e3840c8f9bfd728c9bd6282dad