### PR TITLE
Be more WASM compatible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "[c]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "ms-vscode.cpptools"
+        "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
     },
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -456,7 +456,7 @@ static bool scan(TSLexer* lexer, Stack* stack, const bool* valid_symbols) {
 
 // ---------------------------------------------------------------------------------------
 
-void* tree_sitter_r_external_scanner_create() {
+void* tree_sitter_r_external_scanner_create(void) {
   return stack_new();
 }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -4,7 +4,8 @@
 #include <stdio.h>   // printf()
 #include <stdlib.h>  // getenv()
 #include <string.h>  // memcpy()
-#include <tree_sitter/parser.h>
+
+#include "tree_sitter/parser.h"
 
 enum TokenType {
   NEWLINE,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,5 +1,5 @@
-#include <ctype.h>   // isspace()
 #include <string.h>  // memcpy()
+#include <wctype.h>  // iswspace()
 
 #include "tree_sitter/parser.h"
 
@@ -146,7 +146,7 @@ static void stack_deserialize(Stack* stack, const char* buffer, unsigned len) {
 // ---------------------------------------------------------------------------------------
 
 static void consume_whitespace_and_ignored_newlines(TSLexer* lexer, Stack* stack) {
-  while (isspace(lexer->lookahead)) {
+  while (iswspace(lexer->lookahead)) {
     if (lexer->lookahead != '\n') {
       // Consume all spaces, tabs, etc, unconditionally
       lexer->advance(lexer, true);
@@ -201,7 +201,7 @@ static bool
 scan_newline_or_else(TSLexer* lexer, Stack* stack, const bool* valid_symbols) {
   // Advance to the next non-newline, non-space character,
   // we know we have at least 1 newline because this function was called
-  while (isspace(lexer->lookahead)) {
+  while (iswspace(lexer->lookahead)) {
     if (lexer->lookahead != '\n') {
       lexer->advance(lexer, true);
       continue;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -70,9 +70,17 @@ typedef struct {
 
 static Stack* stack_new(void) {
   Scope* arr = malloc(TREE_SITTER_SERIALIZATION_BUFFER_SIZE);
-  if (arr == NULL) exit(1);
+  if (arr == NULL) {
+    debug_print("`stack_new()` failed. Can't allocate scope array.");
+    return NULL;
+  }
+
   Stack* stack = malloc(sizeof(Stack));
-  if (stack == NULL) exit(1);
+  if (stack == NULL) {
+    debug_print("`stack_new()` failed. Can't allocate stack.");
+    return NULL;
+  }
+
   stack->arr = arr;
   stack->len = 0;
   return stack;
@@ -141,6 +149,10 @@ static void stack_deserialize(Stack* stack, const char* buffer, unsigned len) {
     memcpy(stack->arr, buffer, len);
   }
   stack->len = len;
+}
+
+static inline bool stack_exists(void* stack) {
+  return stack != NULL;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -465,11 +477,19 @@ bool tree_sitter_r_external_scanner_scan(
     TSLexer* lexer,
     const bool* valid_symbols
 ) {
-  return scan(lexer, payload, valid_symbols);
+  if (stack_exists(payload)) {
+    return scan(lexer, payload, valid_symbols);
+  } else {
+    return false;
+  }
 }
 
 unsigned tree_sitter_r_external_scanner_serialize(void* payload, char* buffer) {
-  return stack_serialize(payload, buffer);
+  if (stack_exists(payload)) {
+    return stack_serialize(payload, buffer);
+  } else {
+    return 0;
+  }
 }
 
 void tree_sitter_r_external_scanner_deserialize(
@@ -477,9 +497,13 @@ void tree_sitter_r_external_scanner_deserialize(
     const char* buffer,
     unsigned length
 ) {
-  stack_deserialize(payload, buffer, length);
+  if (stack_exists(payload)) {
+    stack_deserialize(payload, buffer, length);
+  }
 }
 
 void tree_sitter_r_external_scanner_destroy(void* payload) {
-  stack_free(payload);
+  if (stack_exists(payload)) {
+    stack_free(payload);
+  }
 }


### PR DESCRIPTION
Closes #85 

As mentioned in #85, unfortunately we do a few things that aren't WASM compatible, preventing `tree-sitter build-wasm` from working right. Using `exit()` and `vprintf()` are also _bad things_ from the point of view of being included in an R package.

I've worked around the following issues:
- Home grown compilation flag `TREE_SITTER_R_DEBUG` for debugging. This allows us to put usage of `vprintf()` behind a compilation flag that is generally off, making both WASM and R check happy. It also removes our usage of `getenv()`, which isn't supported by WASM either. It seems simpler for us to do this rather than trying to keep using `getenv("TREE_SITTER_DEBUG")`.

- Swap `isspace()` for `iswspace()`. It turns out that tree-sitter supports `iswspace()` in their WASM builds, but not `isspace()`. I don't know why that is, but its easy enough for us to switch back. Presumably that is why we were using this in the first place before I moved us to `isspace()`? https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/wasm/stdlib-symbols.txt

- Fixed up one `()` -> `(void)` signature on our end

- Avoid calling `exit()` entirely, by instead doing a debug log and returning a `NULL` pointer back, which we check for in the other 4 tree-sitter hooks (scan, serialize, deserialize, destroy) before proceeding. A shame we have to care about this at all, but what can you do 🤷 .

As of this PR, `tree-sitter build-wasm` works again!