### PR TITLE
Use string literals rather than regex for `unmatched_delimiter`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -544,10 +544,12 @@ module.exports = grammar({
     // Check for un-matched closing delimiter. This allows us to recover in
     // cases where the parse tree is temporarily incorrect, e.g. because the
     // user has removed the opening delimiter associated with some closing delimiter.
+    // This is not the same as, say, `_close_brace`, as the external scanner doesn't
+    // identify these, the typical internal scanner does.
     unmatched_delimiter: $ => choice(
-      /\}/,
-      /\)/,
-      /\]/
+      "}",
+      ")",
+      "]"
     ),
 
     // This somehow ends up allowing better error recovery

--- a/grammar.js
+++ b/grammar.js
@@ -545,7 +545,9 @@ module.exports = grammar({
     // cases where the parse tree is temporarily incorrect, e.g. because the
     // user has removed the opening delimiter associated with some closing delimiter.
     // This is not the same as, say, `_close_brace`, as the external scanner doesn't
-    // identify these, the typical internal scanner does.
+    // identify these, the typical internal scanner does. It is important for the
+    // underlying string literals to appear in the tree as children of the
+    // `unmatched_delimiter` node so you can tell them apart if you need to.
     unmatched_delimiter: $ => choice(
       "}",
       ")",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2535,16 +2535,16 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "PATTERN",
-          "value": "\\}"
+          "type": "STRING",
+          "value": "}"
         },
         {
-          "type": "PATTERN",
-          "value": "\\)"
+          "type": "STRING",
+          "value": ")"
         },
         {
-          "type": "PATTERN",
-          "value": "\\]"
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },


### PR DESCRIPTION
This has the side effect of ensuring that the specific delimiter appears as an anonymous child of `unmatched_delimiter`, which is important to be able to tell them apart

Normal tree-sitter tests don't show anonymous nodes, but I confirmed in the R package PR that the snapshots get updated to:

<img width="436" alt="Screenshot 2024-04-02 at 1 39 45 PM" src="https://github.com/r-lib/tree-sitter-r/assets/19150088/7b4049fb-c82e-493a-be55-8d4c37c5872d">
