### PR TITLE
Add `tags.scm` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "r"
       ],
       "first-line-regex": "#!.*\\bRscript$",
-      "highlights": "queries/highlights.scm"
+      "highlights": "queries/highlights.scm",
+      "tags": "queries/tags.scm"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "R",
         "r"
       ],
-      "first-line-regex": "#!.*\\bRscript$"
+      "first-line-regex": "#!.*\\bRscript$",
+      "highlights": "queries/highlights.scm"
     }
   ]
 }

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -13,3 +13,9 @@
 (call
     function: (identifier) @name
 ) @reference.call
+
+(call
+    function: (namespace_operator
+        rhs: (identifier) @name
+    )
+) @reference.call

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,15 @@
+(binary_operator
+    lhs: (identifier) @name
+    operator: "<-"
+    rhs: (function_definition)
+) @definition.function
+
+(binary_operator
+    lhs: (identifier) @name
+    operator: "="
+    rhs: (function_definition)
+) @definition.function
+
+(call
+    function: (identifier) @name
+) @reference.call

--- a/test/tags/calls.R
+++ b/test/tags/calls.R
@@ -9,3 +9,9 @@ fn <- function() {
   # ^ reference.call
   #        ^ reference.call
 }
+
+pkg::exported(mtcars, x = 1)
+#      ^ reference.call
+
+pkg:::internal(mtcars, x = 1)
+#      ^ reference.call

--- a/test/tags/calls.R
+++ b/test/tags/calls.R
@@ -1,0 +1,11 @@
+match(a, b)
+# ^ reference.call
+
+fn <- function() {
+  foo() 
+  # ^ reference.call
+
+  bar() + baz()
+  # ^ reference.call
+  #        ^ reference.call
+}

--- a/test/tags/function-definitions.R
+++ b/test/tags/function-definitions.R
@@ -1,0 +1,14 @@
+fn <- function() {
+# <- definition.function  
+}
+
+fn = function() {
+# <- definition.function  
+}
+  
+fn <- function(a, b) {
+# <- definition.function   
+
+  bar <- function() {}
+  # ^ definition.function  
+}


### PR DESCRIPTION
Based on these examples
https://github.com/tree-sitter/tree-sitter-python/blob/master/queries/tags.scm
https://github.com/tree-sitter/tree-sitter-javascript/blob/master/queries/tags.scm
https://github.com/tree-sitter/tree-sitter-rust/blob/master/queries/tags.scm

And the Category/Tag table in this section
https://tree-sitter.github.io/tree-sitter/code-navigation-systems#examples

I used these
- `@definition.function`
- `@reference.call`

I don't _think_ we want any for class, interface, method, module, or implementation. The module one seems interesting, as it is somewhat related to package names, i.e. `dplyr::` or `library(dplyr)`, but I don't think it maps to anything, i.e. `definition.module` would be the creation of the "dplyr module", which is like `namespace dplyr {` in C++, but no equivalent in R, and there doesn't seem to be a `reference.module` oddly.

There also seems to be an undocumented one for constants but I don't think that works for us either
https://github.com/tree-sitter/tree-sitter-python/blob/a22761025cdac6c314b7e3aa48fb44fa9e594d6a/queries/tags.scm#L1

Let me know if you can think of something I'm missing!