### PR TITLE
Allow `_` as the leading character of an `identifier`

### DIFF
--- a/bindings/r/tests/testthat/_snaps/literals.md
+++ b/bindings/r/tests/testthat/_snaps/literals.md
@@ -4,46 +4,46 @@
       node_children_print(node)
     Output
       S-Expression
-      (comment [(1, 0), (1, 82)])
-      
-      Text
-      # TODO: `_foo` is recognized as  `_` and `foo` identifiers. Should it be this way?
-      
-      S-Expression
-      (identifier [(2, 0), (2, 3)])
+      (identifier [(1, 0), (1, 3)])
       
       Text
       foo
       
       S-Expression
-      (identifier [(3, 0), (3, 4)])
+      (identifier [(2, 0), (2, 4)])
       
       Text
       foo2
       
       S-Expression
-      (identifier [(4, 0), (4, 7)])
+      (identifier [(3, 0), (3, 7)])
       
       Text
       foo.bar
       
       S-Expression
-      (identifier [(5, 0), (5, 8)])
+      (identifier [(4, 0), (4, 8)])
       
       Text
       .foo.bar
       
       S-Expression
-      (identifier [(6, 0), (6, 15)])
+      (identifier [(5, 0), (5, 15)])
       
       Text
       .__NAMESPACE__.
       
       S-Expression
-      (identifier [(7, 0), (7, 7)])
+      (identifier [(6, 0), (6, 7)])
       
       Text
       foo_bar
+      
+      S-Expression
+      (identifier [(7, 0), (7, 6)])
+      
+      Text
+      `_foo`
       
       S-Expression
       (identifier [(8, 0), (8, 13)])
@@ -72,18 +72,40 @@
       `\``
       
       S-Expression
-      (identifier [(14, 0), (14, 1)]
-        "_" [(14, 0), (14, 1)]
-      )
+      (comment [(14, 0), (14, 18)])
+      
+      Text
+      # Pipe placeholder
+      
+      S-Expression
+      (identifier [(15, 0), (15, 1)])
       
       Text
       _
       
       S-Expression
-      (identifier [(14, 1), (14, 4)])
+      (comment [(16, 0), (16, 73)])
       
       Text
-      foo
+      # Recognized as a single `_foo` identifier, even if invalid R code (#71).
+      
+      S-Expression
+      (identifier [(17, 0), (17, 4)])
+      
+      Text
+      _foo
+      
+      S-Expression
+      (identifier [(18, 0), (18, 5)])
+      
+      Text
+      __foo
+      
+      S-Expression
+      (identifier [(19, 0), (19, 5)])
+      
+      Text
+      _foo_
       
 
 # comments

--- a/bindings/r/tests/testthat/_snaps/operators.md
+++ b/bindings/r/tests/testthat/_snaps/operators.md
@@ -633,9 +633,7 @@
             argument: (argument [(1, 14), (1, 19)]
               name: (identifier [(1, 14), (1, 15)])
               "=" [(1, 16), (1, 17)]
-              value: (identifier [(1, 18), (1, 19)]
-                "_" [(1, 18), (1, 19)]
-              )
+              value: (identifier [(1, 18), (1, 19)])
             )
             close: ")" [(1, 19), (1, 20)]
           )
@@ -666,9 +664,7 @@
             argument: (argument [(2, 20), (2, 28)]
               name: (identifier [(2, 20), (2, 24)])
               "=" [(2, 25), (2, 26)]
-              value: (identifier [(2, 27), (2, 28)]
-                "_" [(2, 27), (2, 28)]
-              )
+              value: (identifier [(2, 27), (2, 28)])
             )
             close: ")" [(2, 28), (2, 29)]
           )

--- a/bindings/r/tests/testthat/references/literals.R
+++ b/bindings/r/tests/testthat/references/literals.R
@@ -1,20 +1,25 @@
 # ------------------------------------------------------------------------------
 # identifiers
 
-# TODO: `_foo` is recognized as  `_` and `foo` identifiers. Should it be this way?
 foo
 foo2
 foo.bar
 .foo.bar
 .__NAMESPACE__.
 foo_bar
+`_foo`
 `a "literal"`
 `another
 literal \` foo`
 `backslash followed by newline \
 `
 `\``
+# Pipe placeholder
+_
+# Recognized as a single `_foo` identifier, even if invalid R code (#71).
 _foo
+__foo
+_foo_
 
 # ------------------------------------------------------------------------------
 # comments

--- a/grammar.js
+++ b/grammar.js
@@ -505,12 +505,18 @@ module.exports = grammar({
     )),
 
     // Identifiers.
+    // NOTE: `_` isn't a valid way to start an R identifier, but we are a little
+    // lax here and parse it anyways. One reason is because want to support a lone `_` as
+    // the pipe placeholder identifier. It could be included as a separate `"_"` choice,
+    // but then `_foo` parses as two identifiers: `_` and `foo`, making it impossible to
+    // check that `_foo` is an invalid identifier. It seems simpler to parse `_foo` as a
+    // single identifier, and then let downstream consumers do further checks on the
+    // validity as needed (#71).
     identifier: $ => choice(
-      token("_"), 
       $._identifier, 
       $._quoted_identifier
     ),
-    _identifier: $ => /[\p{XID_Start}.][\p{XID_Continue}.]*/,
+    _identifier: $ => /[\p{XID_Start}._][\p{XID_Continue}.]*/,
     _quoted_identifier: $ => /`((?:\\(.|\n))|[^`\\])*`/,
 
     // Keywords.

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2468,13 +2468,6 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "_"
-          }
-        },
-        {
           "type": "SYMBOL",
           "name": "_identifier"
         },
@@ -2486,7 +2479,7 @@
     },
     "_identifier": {
       "type": "PATTERN",
-      "value": "[\\p{XID_Start}.][\\p{XID_Continue}.]*"
+      "value": "[\\p{XID_Start}._][\\p{XID_Continue}.]*"
     },
     "_quoted_identifier": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3454,10 +3454,6 @@
     "named": false
   },
   {
-    "type": "_",
-    "named": false
-  },
-  {
     "type": "break",
     "named": true
   },

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -8,14 +8,19 @@ foo.bar
 .foo.bar
 .__NAMESPACE__.
 foo_bar
+`_foo`
 `a "literal"`
 `another
 literal \` foo`
 `backslash followed by newline \
 `
 `\``
-# Recognized as `_` and `foo` identifiers. Should it be this way?
+# Pipe placeholder
+_
+# Recognized as a single `_foo` identifier, even if invalid R code (#71).
 _foo
+__foo
+_foo_
 
 
 --------------------------------------------------------------------------------
@@ -31,7 +36,11 @@ _foo
   (identifier)
   (identifier)
   (identifier)
+  (identifier)
   (comment)
+  (identifier)
+  (comment)
+  (identifier)
   (identifier)
   (identifier))
 


### PR DESCRIPTION
Closes https://github.com/r-lib/tree-sitter-r/issues/71

So `_foo` is now parsed as a single identifier, even if it is invalid R code. This gives downstream consumers an opportunity to at least do a follow up check that the `identifier` is valid R code using their own means (some regex check probably).

Previously `_foo` was being parsed as two identifiers: `_` and `foo`. This was because we allowed a single `token("_")` to represent the pipe placeholder. If we removed that, then we could instead error on `_foo` as invalid syntax. But then to support `_` we'd have to add in very specific rules around `|>` to define the scopes where a long `_` pipe placeholder is allowed, and that doesn't seem worth it, even if it is technically probably more correct (I do think `main` tries something like this).