### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [devel]
+## 1.0.0
 
 - This release incorporates a complete rewrite of the grammar which has been incubating on the `next` branch for the past two years. It contains many bug fixes and improvements. If you still need to use the previous version, you can pin to the `main-old` branch, which is the commit just before the `next` branch was merged in.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-r"
-version = "0.20.1"
+version = "1.0.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-r"
 description = "R grammar for the tree-sitter parsing library"
-version = "0.20.1"
+version = "1.0.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "R"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.20.1
+VERSION := 1.0.0
 
 LANGUAGE_NAME := tree-sitter-r
 

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: treesitter.r
 Title: R Grammar for tree-sitter
-Version: 0.20.1.9000
+Version: 0.0.0.9000
 Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd"))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-r",
-  "version": "0.20.1",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "R grammar for tree-sitter",
   "repository": "github:r-lib/tree-sitter-r",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-r"
 description = "R grammar for tree-sitter"
-version = "0.20.1"
+version = "1.0.0"
 keywords = ["incremental", "parsing", "tree-sitter", "r"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
Only doing Rust release at the moment, still need to figure out how to do the node release (do we need a key?).

Bumping to 1.0.0 as recommended by https://github.com/tree-sitter/tree-sitter/pull/3094, which suggests that grammars should use semver from here on out (which makes complete sense to us, grammars should be able to evolve separately from core tree-sitter in terms of versioning and releases).