### PR TITLE
Update to tree-sitter 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## devel
 
+- Changed tree-sitter dependency from `>=0.21.0` to `0.23.0`, which removes the dependency from the generated parser on a specific tree-sitter version.
+
 - Fixed an issue where the `program` node didn't always start at `(0, 0)` (#134).
 
 - To align better with the R grammar and to greatly simplify the possible states in the tree-sitter grammar, some fields are no longer optional (#132).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## devel
 
-- Changed tree-sitter dependency from `>=0.21.0` to `0.23.0`, which removes the dependency from the generated parser on a specific tree-sitter version.
+- Switched to using `tree-sitter-language` in the Rust bindings to remove a dependency on a specific `tree-sitter` crate version (#133).
 
 - Fixed an issue where the `program` node didn't always start at `(0, 0)` (#134).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-r"
 description = "R grammar for the tree-sitter parsing library"
-version = "1.0.1"
+version = "1.1.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "R"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.21.0"
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.23"
 
 [build-dependencies]
 cc = "1.0.92"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-r"
 description = "R grammar for the tree-sitter parsing library"
-version = "1.1.0"
+version = "1.0.1"
 license = "MIT"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "R"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.1.0
+VERSION := 1.0.1
 
 LANGUAGE_NAME := tree-sitter-r
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.1
+VERSION := 1.1.0
 
 LANGUAGE_NAME := tree-sitter-r
 

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_r_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-r"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_r "github.com/tree-sitter/tree-sitter-r/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-r
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_r
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_r.language())
+        except Exception:
+            self.fail("Error loading R grammar")

--- a/bindings/python/tree_sitter_r/binding.c
+++ b/bindings/python/tree_sitter_r/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_r(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_r());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_r(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: treesitter.r
 Title: 'R' Grammar for 'Tree-Sitter'
-Version: 1.0.1.9000
+Version: 1.1.0.9000
 Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd")),

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: treesitter.r
 Title: 'R' Grammar for 'Tree-Sitter'
-Version: 1.1.0.9000
+Version: 1.0.1.9000
 Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd")),

--- a/bindings/swift/TreeSitterRTests/TreeSitterRTests.swift
+++ b/bindings/swift/TreeSitterRTests/TreeSitterRTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterR
+
+final class TreeSitterRTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_r())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading R grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-r
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/tree-sitter/tree-sitter-r
 
 go 1.23
 
-require github.com/tree-sitter/go-tree-sitter v0.23
+require github.com/tree-sitter/go-tree-sitter v0.23.1
+
+require github.com/mattn/go-pointer v0.0.1 // indirect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-r",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-r",
-      "version": "1.1.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,55 +1,29 @@
 {
   "name": "tree-sitter-r",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-r",
-      "version": "0.0.1",
+      "version": "1.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.14.2"
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       },
       "devDependencies": {
-        "tree-sitter": "^0.20",
-        "tree-sitter-cli": "^0.20"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "prebuildify": "^6.0.0",
+        "tree-sitter-cli": "^0.23.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/base64-js": {
@@ -109,59 +83,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "dev": true,
@@ -170,43 +91,10 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -232,38 +120,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.7",
       "dev": true,
@@ -277,48 +133,50 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nan": {
-      "version": "2.14.2",
-      "license": "MIT"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-abi": {
-      "version": "2.30.1",
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
+      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^5.4.1"
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
+    "node_modules/node-addon-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
+        "path-key": "^3.0.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/once": {
@@ -329,36 +187,33 @@
         "wrappy": "1"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "6.1.4",
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prebuildify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
+      "integrity": "sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
+        "minimist": "^1.2.5",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
+        "node-abi": "^3.3.0",
+        "npm-run-path": "^3.1.0",
         "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
+        "tar-fs": "^2.1.0"
       },
       "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
+        "prebuildify": "bin.js"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -367,20 +222,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -402,50 +243,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "5.7.1",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string_decoder": {
@@ -454,38 +261,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tar-fs": {
@@ -515,47 +290,35 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.20.0",
-      "dev": true,
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "nan": "^2.14.0",
-        "prebuild-install": "^6.0.1"
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.7",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
+      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -564,37 +327,6 @@
     }
   },
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "dev": true
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
-    },
     "base64-js": {
       "version": "1.5.1",
       "dev": true
@@ -620,37 +352,6 @@
       "version": "1.1.4",
       "dev": true
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "dev": true
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "dev": true
-    },
-    "decompress-response": {
-      "version": "4.2.1",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^2.0.0"
-      }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "dev": true
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "dev": true,
@@ -658,34 +359,8 @@
         "once": "^1.4.0"
       }
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "dev": true
-    },
     "fs-constants": {
       "version": "1.0.0",
-      "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
       "dev": true
     },
     "ieee754": {
@@ -696,25 +371,6 @@
       "version": "2.0.4",
       "dev": true
     },
-    "ini": {
-      "version": "1.3.8",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "2.1.0",
-      "dev": true
-    },
     "minimist": {
       "version": "1.2.7",
       "dev": true
@@ -723,37 +379,33 @@
       "version": "0.5.3",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.2"
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "dev": true
-    },
     "node-abi": {
-      "version": "2.30.1",
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
+      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
       "dev": true,
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "^7.3.5"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
+    "node-addon-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ=="
+    },
+    "node-gyp-build": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw=="
+    },
+    "npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "path-key": "^3.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -762,28 +414,25 @@
         "wrappy": "1"
       }
     },
-    "prebuild-install": {
-      "version": "6.1.4",
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prebuildify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
+      "integrity": "sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==",
       "dev": true,
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
+        "minimist": "^1.2.5",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
+        "node-abi": "^3.3.0",
+        "npm-run-path": "^3.1.0",
         "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
+        "tar-fs": "^2.1.0"
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -791,16 +440,6 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
       }
     },
     "readable-stream": {
@@ -817,29 +456,10 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "dev": true
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "simple-get": {
-      "version": "3.1.1",
-      "dev": true,
-      "requires": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -847,26 +467,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true
     },
     "tar-fs": {
       "version": "2.1.1",
@@ -890,34 +490,24 @@
       }
     },
     "tree-sitter": {
-      "version": "0.20.0",
-      "dev": true,
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "peer": true,
       "requires": {
-        "nan": "^2.14.0",
-        "prebuild-install": "^6.0.1"
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       }
     },
     "tree-sitter-cli": {
-      "version": "0.20.7",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.0.tgz",
+      "integrity": "sha512-/DdQaPCCOrOYGp9FxGdhFUnHIrjhfbYatQXgNIcmaAOpPunpnDj2vsO/H+svsfQLaFsQ1C+BjgPhpbV28zka1w==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
       "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-r",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "R grammar for tree-sitter",
   "repository": "github:r-lib/tree-sitter-r",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.23.0"
+    "tree-sitter": "^0.21.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
     "prebuildify": "^6.0.0"
   },
   "scripts": {
-    "build": "tree-sitter generate --no-bindings",
-    "prestart": "tree-sitter build --wasm -o tree-sitter-r.wasm",
-    "start": "tree-sitter playground",
-    "test": "tree-sitter test",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "tree-sitter": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-r",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "R grammar for tree-sitter",
   "repository": "github:r-lib/tree-sitter-r",
@@ -26,7 +26,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.1"
+    "tree-sitter": "^0.23.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {
@@ -34,14 +34,14 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.22.2",
+    "tree-sitter-cli": "^0.23.0",
     "prebuildify": "^6.0.0"
   },
   "scripts": {
-    "build": "tree-sitter generate --no-bindings",
-    "prestart": "tree-sitter build --wasm -o tree-sitter-r.wasm",
-    "start": "tree-sitter playground",
-    "test": "tree-sitter test",
+    "build": "npx tree-sitter-cli generate --no-bindings",
+    "prestart": "npx tree-sitter-cli build --wasm -o tree-sitter-r.wasm",
+    "start": "npx tree-sitter-cli playground",
+    "test": "npx tree-sitter-cli test",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip"
   },

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "prebuildify": "^6.0.0"
   },
   "scripts": {
-    "build": "npx tree-sitter-cli generate --no-bindings",
-    "prestart": "npx tree-sitter-cli build --wasm -o tree-sitter-r.wasm",
-    "start": "npx tree-sitter-cli playground",
-    "test": "npx tree-sitter-cli test",
+    "build": "tree-sitter generate --no-bindings",
+    "prestart": "tree-sitter build --wasm -o tree-sitter-r.wasm",
+    "start": "tree-sitter playground",
+    "test": "tree-sitter test",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-r"
 description = "R grammar for tree-sitter"
-version = "1.0.1"
+version = "1.1.0"
 keywords = ["incremental", "parsing", "tree-sitter", "r"]
 classifiers = [
   "Intended Audience :: Developers",
@@ -27,7 +27,7 @@ readme = "README.md"
 Homepage = "https://github.com/tree-sitter/tree-sitter-r"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.23"]
 
 [tool.cibuildwheel]
 build = "cp38-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-r"
 description = "R grammar for tree-sitter"
-version = "1.1.0"
+version = "1.0.1"
 keywords = ["incremental", "parsing", "tree-sitter", "r"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {


### PR DESCRIPTION
Tree-sitter released version 0.23 recently. This contains a breaking, but ultimately very good change to how parser bindings work (https://github.com/tree-sitter/tree-sitter/pull/3069). The TLDR of that change is that parsers do not depend on tree-sitter anymore, but instead on a shard (and supposedly very stable) tree-sitter-language crate. As a result, clients are free to chose their tree-sitter version as the parser ABI is supported. Library and parser versions are less tighly coupled, and it should no longer be necessary to move all the parsers to the next tree-sitter version in lock-step to be able to upgrade the library.

Most of the changes in this PR are from running tree-sitter generate. I'll add comments on other changes I did to explain why I thought they are necessary, or where I'm not sure I did it correctly.