### PR TITLE
Simplify `_hex_literal` at the advice of `tree-sitter generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## devel
 
+- The internal `_hex_literal` rule was simplified slightly (#138).
+
 ## 1.1.0
 
 - Switched to using `tree-sitter-language` in the Rust bindings to remove a dependency on a specific `tree-sitter` crate version (#133).

--- a/grammar.js
+++ b/grammar.js
@@ -455,7 +455,7 @@ module.exports = grammar({
     complex: $ => seq($._float_literal, "i"),
     float: $ => $._float_literal,
 
-    _hex_literal: $ => seq(/0[xX][0-9a-fA-F]+/),
+    _hex_literal: $ => /0[xX][0-9a-fA-F]+/,
     _number_literal: $ => /(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d*)?/,
     _float_literal: $ => choice($._hex_literal, $._number_literal),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2277,13 +2277,8 @@
       "name": "_float_literal"
     },
     "_hex_literal": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "PATTERN",
-          "value": "0[xX][0-9a-fA-F]+"
-        }
-      ]
+      "type": "PATTERN",
+      "value": "0[xX][0-9a-fA-F]+"
     },
     "_number_literal": {
       "type": "PATTERN",


### PR DESCRIPTION
- [x] Rebase on main after merging https://github.com/r-lib/tree-sitter-r/pull/136, and move news bullet to the right spot