### PR TITLE
Changed go module path to match github repository

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_r "github.com/tree-sitter/tree-sitter-r/bindings/go"
+	tree_sitter_r "github.com/r-lib/tree-sitter-r/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-r
+module github.com/r-lib/tree-sitter-r
 
 go 1.23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license.text = "MIT"
 readme = "README.md"
 
 [project.urls]
-Homepage = "https://github.com/tree-sitter/tree-sitter-r"
+Homepage = "https://github.com/r-lib/tree-sitter-r"
 
 [project.optional-dependencies]
 core = ["tree-sitter~=0.23"]


### PR DESCRIPTION
I'm unable to add the go bindings to a project because the module path doesn't match the require path.