### PR TITLE
Introduce a `START` external to ensure that `program` starts at `(0, 0)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## devel
 
+- Fixed another issue where the `program` node didn't start at `(0, 0)` if there was leading whitespace before the first token (#151).
+
 - Newlines after `function` but before the `()` are again allowed (#145).
 
 - Newlines are now allowed after an `else` but before the `alternative` (#141).

--- a/bindings/r/tests/testthat/test-start.R
+++ b/bindings/r/tests/testthat/test-start.R
@@ -1,0 +1,45 @@
+test_that("`program` always starts at `(0, 0)`", {
+  # https://github.com/r-lib/tree-sitter-r/issues/151
+  #
+  # We don't have tree-sitter corpus tests for this, as this is very specific
+  # to node positions, and the tree-sitter test infrastructure doesn't report
+  # that.
+  skip_if_not_installed("treesitter")
+
+  language <- language()
+  parser <- treesitter::parser(language)
+
+  test_program_position <- function(text, end_point, end_byte) {
+    tree <- treesitter::parser_parse(parser, text)
+
+    # Root node is `program`
+    node <- treesitter::tree_root_node(tree)
+
+    expect_identical(treesitter::node_start_point(node), treesitter::point(0, 0))
+    expect_identical(treesitter::node_end_point(node), end_point)
+
+    expect_identical(treesitter::node_start_byte(node), 0)
+    expect_identical(treesitter::node_end_byte(node), end_byte)
+  }
+
+  # Empty file
+  test_program_position("", treesitter::point(0, 0), 0)
+
+  # Only whitespace
+  test_program_position("  ", treesitter::point(0, 2), 2)
+
+  # Only newlines (Unix)
+  test_program_position("\n\n", treesitter::point(2, 0), 2)
+
+  # Only newlines (Windows)
+  test_program_position("\r\n\r\n", treesitter::point(2, 0), 4)
+
+  # Leading whitespace
+  test_program_position("  x", treesitter::point(0, 3), 3)
+
+  # Leading newlines (Unix)
+  test_program_position("\n\nx", treesitter::point(2, 1), 3)
+
+  # Leading newlines (Windows)
+  test_program_position("\r\n\r\nx", treesitter::point(2, 1), 5)
+})

--- a/bindings/r/tests/testthat/test-start.R
+++ b/bindings/r/tests/testthat/test-start.R
@@ -42,4 +42,13 @@ test_that("`program` always starts at `(0, 0)`", {
 
   # Leading newlines (Windows)
   test_program_position("\r\n\r\nx", treesitter::point(2, 1), 5)
+
+  # Leading whitespace before comment
+  test_program_position("  # hi", treesitter::point(0, 6), 6)
+
+  # Leading newlines before comment (Unix)
+  test_program_position("\n\n# hi", treesitter::point(2, 4), 6)
+
+  # Leading newlines before comment (Windows)
+  test_program_position("\r\n\r\n# hi", treesitter::point(2, 4), 8)
 })

--- a/grammar.js
+++ b/grammar.js
@@ -179,6 +179,7 @@ module.exports = grammar({
   ],
 
   externals: $ => [
+    $._start,
     $._newline,
     $._semicolon,
     $._raw_string_literal,
@@ -202,7 +203,11 @@ module.exports = grammar({
 
   rules: {
     // Top-level rules.
-    program: $ => repeat(choice($._expression, $._semicolon, $._newline)),
+    // The zero width `$._start` ensures that `program` starts at `(0, 0)`.
+    program: $ => seq(
+        $._start,
+        repeat(choice($._expression, $._semicolon, $._newline))
+    ),
 
     // Function definitions.
     function_definition: $ => withPrec(PREC.FUNCTION_OR_LOOP, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3,24 +3,33 @@
   "word": "identifier",
   "rules": {
     "program": {
-      "type": "REPEAT",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_semicolon"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_newline"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_start"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_semicolon"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "function_definition": {
       "type": "PREC_LEFT",
@@ -2809,6 +2818,10 @@
   "conflicts": [],
   "precedences": [],
   "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_start"
+    },
     {
       "type": "SYMBOL",
       "name": "_newline"


### PR DESCRIPTION
Closes #151 

Note that https://github.com/r-lib/tree-sitter-r/pull/134 is where this was introduced. That is a similar but slightly different issue where we were actually consuming leading newlines at the beginning of the file, when really we should have been emitting those as `NEWLINE` tokens. Fixing that ended up causing this issue somehow.

---

Addresses https://github.com/posit-dev/positron/issues/5258, and I can confirm on my Windows VM that if I feed this fix all the way through to ark and then Positron, then everything does look good now 👍 

Before (where our indent handler was seeing a column position of 1 for `program`):

https://github.com/user-attachments/assets/4fc6c5b8-5888-418a-a59d-a7e6ea563950

After (where now it sees a correct column position of 0 for `program`)


https://github.com/user-attachments/assets/b493280b-5bd4-48c4-a7c9-f4266cc8c6ba

