### PR TITLE
Change to a scoped package temporarily

### DIFF
--- a/.github/workflows/package-npm.yaml
+++ b/.github/workflows/package-npm.yaml
@@ -158,6 +158,9 @@ jobs:
         continue-on-error: true
         run: mv -v prebuilds/*.wasm .
       - name: Publish to npm
-        run: npm publish
+        # This is the only thing we change, because we currently publish a scoped package,
+        # so we need `--access public` because scoped packages are private by default (#41)
+        run: npm publish --access public
+        # run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tree-sitter-r",
+  "name": "@davisvaughan/tree-sitter-r",
   "version": "1.2.0",
   "description": "R grammar for tree-sitter",
   "repository": {


### PR DESCRIPTION
For #41 

While we are waiting on npm to transfer us `tree-sitter-r` on npm from the security team, we should be able to temporarily publish it under my name as a scoped package.

I was going to publish it under an r-lib org, but some other person is already name squatting on that for no good reason https://www.npmjs.com/org/r-lib.