### PR TITLE
fix: Exclude Trailing `\r` from Comment Nodes on CRLF-Formatted Files

### DIFF
--- a/bindings/r/tests/testthat/test-comments.R
+++ b/bindings/r/tests/testthat/test-comments.R
@@ -1,0 +1,34 @@
+test_that("comments don't include a trailing `\\r` on CRLF line endings", {
+  # https://github.com/r-lib/tree-sitter-r/pull/184
+  #
+  # We don't have tree-sitter corpus tests for this, as the trailing `\r` only
+  # affects the comment's end position, not the tree structure, and the
+  # tree-sitter test infrastructure doesn't report node positions.
+  skip_if_not_installed("treesitter")
+
+  language <- language()
+  parser <- treesitter::parser(language)
+
+  test_comment_position <- function(text, end_point, end_byte) {
+    tree <- treesitter::parser_parse(parser, text)
+    node <- treesitter::node_child(treesitter::tree_root_node(tree), 1)
+
+    expect_identical(treesitter::node_type(node), "comment")
+    expect_identical(treesitter::node_text(node), "# comment")
+
+    expect_identical(treesitter::node_start_point(node), treesitter::point(0, 0))
+    expect_identical(treesitter::node_end_point(node), end_point)
+
+    expect_identical(treesitter::node_start_byte(node), 0)
+    expect_identical(treesitter::node_end_byte(node), end_byte)
+  }
+
+  # No line ending
+  test_comment_position("# comment", treesitter::point(0, 9), 9)
+
+  # Unix
+  test_comment_position("# comment\n", treesitter::point(0, 9), 9)
+
+  # Windows. The comment stops before the `\r`, which is treated as whitespace.
+  test_comment_position("# comment\r\n", treesitter::point(0, 9), 9)
+})

--- a/bindings/r/tests/testthat/test-comments.R
+++ b/bindings/r/tests/testthat/test-comments.R
@@ -4,6 +4,10 @@ test_that("comments don't include a trailing `\\r` on CRLF line endings", {
   # We don't have tree-sitter corpus tests for this, as the trailing `\r` only
   # affects the comment's end position, not the tree structure, and the
   # tree-sitter test infrastructure doesn't report node positions.
+  #
+  # Our `grammar.js` `comment` regex of `[^\r\n]*` matches other grammars
+  # https://github.com/tree-sitter/tree-sitter-c-sharp/pull/181
+  # https://github.com/tree-sitter/tree-sitter-javascript/blob/58404d8cf191d69f2674a8fd507bd5776f46cb11/grammar.js#L1048
   skip_if_not_installed("treesitter")
 
   language <- language()
@@ -16,7 +20,10 @@ test_that("comments don't include a trailing `\\r` on CRLF line endings", {
     expect_identical(treesitter::node_type(node), "comment")
     expect_identical(treesitter::node_text(node), "# comment")
 
-    expect_identical(treesitter::node_start_point(node), treesitter::point(0, 0))
+    expect_identical(
+      treesitter::node_start_point(node),
+      treesitter::point(0, 0)
+    )
     expect_identical(treesitter::node_end_point(node), end_point)
 
     expect_identical(treesitter::node_start_byte(node), 0)

--- a/grammar.js
+++ b/grammar.js
@@ -749,7 +749,7 @@ module.exports = grammar({
     ),
 
     // Comments.
-    comment: $ => token(withPrec(PREC.COMMENT, /#.*/)),
+    comment: $ => token(withPrec(PREC.COMMENT, seq('#', /[^\r\n]*/))),
 
     // Commas. We include these in the AST so we can figure out the
     // argument call position. This is necessary given how R tolerates

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2880,8 +2880,17 @@
         "type": "PREC",
         "value": -1,
         "content": {
-          "type": "PATTERN",
-          "value": "#.*"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "#"
+            },
+            {
+              "type": "PATTERN",
+              "value": "[^\\r\\n]*"
+            }
+          ]
         }
       }
     },

--- a/src/parser.c
+++ b/src/parser.c
@@ -3739,18 +3739,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 3:
       if (lookahead == '"') ADVANCE(71);
-      if (lookahead == '#') ADVANCE(75);
+      if (lookahead == '#') ADVANCE(76);
       if (lookahead == '\\') ADVANCE(9);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(76);
+          lookahead == ' ') ADVANCE(75);
       if (lookahead != 0) ADVANCE(77);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(72);
+      if (lookahead == '#') ADVANCE(73);
       if (lookahead == '\'') ADVANCE(70);
       if (lookahead == '\\') ADVANCE(9);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(73);
+          lookahead == ' ') ADVANCE(72);
       if (lookahead != 0) ADVANCE(74);
       END_STATE();
     case 5:
@@ -4049,19 +4049,20 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym__single_quoted_string_content_token1);
-      if (lookahead == '\n') ADVANCE(74);
-      if (lookahead != 0 &&
-          lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(72);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(aux_sym__single_quoted_string_content_token1);
-      if (lookahead == '#') ADVANCE(72);
+      if (lookahead == '#') ADVANCE(73);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(73);
+          lookahead == ' ') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\'' &&
           lookahead != '\\') ADVANCE(74);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(aux_sym__single_quoted_string_content_token1);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(74);
+      if (lookahead != 0 &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(73);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym__single_quoted_string_content_token1);
@@ -4071,20 +4072,21 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym__double_quoted_string_content_token1);
-      if (lookahead == '\n') ADVANCE(77);
-      if (lookahead != 0 &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(75);
-      END_STATE();
-    case 76:
-      ACCEPT_TOKEN(aux_sym__double_quoted_string_content_token1);
-      if (lookahead == '#') ADVANCE(75);
+      if (lookahead == '#') ADVANCE(76);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(76);
+          lookahead == ' ') ADVANCE(75);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '#' &&
           lookahead != '\\') ADVANCE(77);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(aux_sym__double_quoted_string_content_token1);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(76);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym__double_quoted_string_content_token1);
@@ -4185,7 +4187,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 96:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(96);
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(96);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_comma);


### PR DESCRIPTION
Currently, when parsing files with CRLF (`\r\n`) line endings, comment nodes incorrectly include the trailing `\r` character.

This PR updates the grammar to exclude `\r` from the comment node content, aligning the behavior with other grammars such as [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript/blob/6fbef40512dcd9f0a61ce03a4c9ae7597b36ab5c/grammar.js#L974).

#### Example Input

```text
# comment
```

### Output of `tree-sitter parse` 

#### Before this PR

```lisp
(program [0, 0] - [1, 0]
  (comment [0, 0] - [0, 10]))
```

#### Using this PR

```lisp
(program [0, 0] - [1, 0]
  (comment [0, 0] - [0, 9]))
```

---

* Also fixes formatting of `grammar.js` in line 74 and 208/209.