### PR TITLE
fix: include external scanner in Go binding

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,7 +2,7 @@ package tree_sitter_r
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
-// // NOTE: if your language has an external scanner, add it here.
+// #include "../../src/scanner.c"
 import "C"
 
 import "unsafe"


### PR DESCRIPTION
This PR fixes the issue where external scanner (`scanner.c`) is not linked for Go binding, causing the following error when building.

```
# command-line-arguments
/opt/homebrew/Cellar/go/1.24.3/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
/usr/bin/cc -arch arm64 -Wl,-headerpad,1144 -o $WORK/b001/exe/a.out -Qunused-arguments /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/go.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000000.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000001.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000002.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000003.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000004.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000005.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000006.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000007.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000008.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000009.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000010.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000011.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000012.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000013.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000014.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000015.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000016.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000017.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000018.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000019.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000020.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000021.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000022.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000023.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000024.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000025.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000026.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000027.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000028.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000029.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000030.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000031.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000032.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000033.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000034.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000035.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000036.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000037.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000038.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000039.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000040.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000041.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000042.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000043.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000044.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000045.o /var/folders/hc/1zy_rjrj6qj_pnjqm53x60_40000gn/T/go-link-2332361699/000046.o -lresolv -framework CoreFoundation -framework Security -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -O2 -g -framework CoreFoundation -O2 -g
Undefined symbols for architecture arm64:
  "_tree_sitter_r_external_scanner_create", referenced from:
      _tree_sitter_r.language in 000001.o
  "_tree_sitter_r_external_scanner_deserialize", referenced from:
      _tree_sitter_r.language in 000001.o
  "_tree_sitter_r_external_scanner_destroy", referenced from:
      _tree_sitter_r.language in 000001.o
  "_tree_sitter_r_external_scanner_scan", referenced from:
      _tree_sitter_r.language in 000001.o
  "_tree_sitter_r_external_scanner_serialize", referenced from:
      _tree_sitter_r.language in 000001.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```