### PR TITLE
Include LICENSE file in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
+    "/LICENSE",
     "bindings/rust/*",
     "grammar.js",
     "queries/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
-    "/LICENSE",
+    "LICENSE",
     "bindings/rust/*",
     "grammar.js",
     "queries/*",


### PR DESCRIPTION
This is needed by the MIT license and required when packaging in distributions like Fedora

```
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE
```