### PR TITLE
Don't consume `else` if it is part of a larger `identifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## devel
 
+- `else` is no longer consumed as eagerly in some special cases (#200).
+
 - Integers and complex numbers with a leading decimal, such as `.1L` and `.1i`, now parse correctly (#190).
 
 - Hexadecimal constants with decimals are now supported (#191).

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -207,28 +207,79 @@ static inline void consume_whitespace_and_ignored_newlines(TSLexer* lexer, Stack
   }
 }
 
+// Check for an identifier continuation character
+//
+// Identifier continuation characters are defined in `identifier` in `grammar.js` as:
+// - `XID_Continue` (0-9, a-z, A-Z, `_`, unicode support)
+// - `.`
+//
+// We can't easily test `XID_Continue` from the scanner, but we can get close!
+//
+// For ASCII values (< 128):
+// - `iswalnum()` handles 0-9, a-z, A-Z
+// - `_` specially supported
+// - `.` specially supported
+// For non-ASCII values (>= 128):
+// - Assume continuation
+//
+// The unhandled values in the ASCII range all correspond to non-continuation characters
+// (like `>` or `#` or `"`).
+//
+// Assuming non-ASCII values are continuation characters is a bit of an
+// overapproximation. The point is to allow this example to correctly parse as
+// `elseμ <- 1`, aligning with R.
+//
+// ```r
+// {
+//   if (TRUE) 1
+//   elseμ <- 1
+// }
+// ```
+//
+// However, we'd also parse the following example as `else· <- 1`, but really
+// R's `iswalnum()` in UTF-8 locale would reject this and cause a syntax error
+// on the U+00B7 middle dot. Being a bit more lax where R would generate a
+// syntax error is okay, especially since it is fairly pathological.
+//
+// ```r
+// {
+//   if (TRUE) 1
+//   else· <- 1
+// }
+// ```
+//
+// https://github.com/wch/r-source/blob/0a30adbff0fcff79ef608276024949881134bd08/src/main/gram.y#L3397-L3433
+static inline bool is_identifier_continuation(int x) {
+  return iswalnum(x) || x == '_' || x == '.' || x >= 128;
+}
+
 static inline bool scan_else(TSLexer* lexer) {
   if (lexer->lookahead != 'e') {
     return false;
   }
-
   lexer->advance(lexer, false);
+
   if (lexer->lookahead != 'l') {
     return false;
   }
-
   lexer->advance(lexer, false);
+
   if (lexer->lookahead != 's') {
     return false;
   }
-
   lexer->advance(lexer, false);
+
   if (lexer->lookahead != 'e') {
+    return false;
+  }
+  lexer->advance(lexer, false);
+
+  // Check that this `else` isn't part of a larger identifier, like `else_idx` (#200)
+  if (is_identifier_continuation(lexer->lookahead)) {
     return false;
   }
 
   // We found `else`, return special `external` for it
-  lexer->advance(lexer, false);
   lexer->mark_end(lexer);
   lexer->result_symbol = ELSE;
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1226,6 +1226,127 @@ if (TRUE) 1 else
     (float)))
 
 ================================================================================
+Identifiers starting with `else` that are not the `else` keyword (#200)
+================================================================================
+
+# ASCII letter
+{
+  if (TRUE) 1
+  elseidx <- 1
+}
+
+# ASCII number
+{
+  if (TRUE) 1
+  else1idx <- 1
+}
+
+# ASCII `_`
+{
+  if (TRUE) 1
+  else_idx <- 1
+}
+
+# ASCII `.`
+{
+  if (TRUE) 1
+  else.idx <- 1
+}
+
+# Non-ASCII, but considered `iswalnum()` in R with UTF-8 locale.
+# Not considered `iswalnum()` in our scanner with C locale, but
+# our overapproximation with `>= 128` allows this and aligns with R.
+{
+  if (TRUE) 1
+  elseμ <- 1
+}
+
+# Non-ASCII (U+00B7), rejected by R as syntax error since `iswalnum()` returns false.
+# Our overapproximation with `>= 128` allows this, but that's ok since the R
+# side behavior is a syntax error.
+{
+  if (TRUE) 1
+  else· <- 1
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float)))
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float)))
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float)))
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float)))
+  (comment)
+  (comment)
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float)))
+  (comment)
+  (comment)
+  (comment)
+  (braced_expression
+    body: (if_statement
+      condition: (true)
+      consequence: (float))
+    body: (binary_operator
+      lhs: (identifier)
+      rhs: (float))))
+
+================================================================================
+Identifiers starting with `else` that are not the `else` keyword - 2 (#200)
+================================================================================
+
+# Correctly treats `else.x` as a single identifier, not as `else` followed by `.x`,
+# but should really be a syntax error. See https://github.com/r-lib/tree-sitter-r/issues/194.
+if (TRUE) {
+  1
+} else.x
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (comment)
+  (if_statement
+    (true)
+    (braced_expression
+      (float)))
+  (identifier))
+
+================================================================================
 For
 ================================================================================
 
@@ -2090,7 +2211,7 @@ fn(return = )
 
 # One specific example from #189
 switch(
-  x, 
+  x,
   return = ,
 )
 


### PR DESCRIPTION
Closes https://github.com/r-lib/tree-sitter-r/issues/200

We can't directly emulate the JS side `XID_Continue` or R's `iswalnum()` in UTF-8 locale, so this is a best effort approach, but I think it should work pretty well in all but the most pathological cases. And even in those pathological cases, R would generate a syntax error on something that we'd parse. So the important thing is that R isn't parsing something that we reject.